### PR TITLE
Add skl2onnx 1.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,15 +12,17 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - numpy >=1.15
     - onnx >=1.2.1
     - onnxconverter-common >=1.7.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,12 +41,21 @@ test:
     - pip
 
 about:
-  home: https://github.com/onnx/sklearn-onnx
+  home: https://onnx.ai/sklearn-onnx/
   summary: Convert scikit-learn models to ONNX
+  description: |
+    sklearn-onnx converts scikit-learn models to ONNX. Once in the ONNX format, you can use tools like `ONNX Runtime` for high performance scoring. All converters are tested with onnxruntime.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  dev_url: https://github.com/onnx/sklearn-onnx
+  doc_url: https://onnx.ai/sklearn-onnx/api_summary.html
+
 
 extra:
   recipe-maintainers:
     - xhochy
     - janjagusch
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - onnx >=1.2.1
     - onnxconverter-common >=1.7.0
     - protobuf 
-    - scikit-learn <=1.1.1
+    - scikit-learn >=0.19,<=1.1.1
     - scipy >=1.0
     - packaging
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,3 @@ extra:
   recipe-maintainers:
     - xhochy
     - janjagusch
-  skip-lints:
-    - missing_doc_source_url
-    - missing_license_url


### PR DESCRIPTION
# skl2onnx 1.13
upstream: https://github.com/onnx/sklearn-onnx/tree/1.13
jira: https://anaconda.atlassian.net/browse/PKG-932
license: https://github.com/onnx/sklearn-onnx/blob/1.13/LICENSE
`setup.py`: https://github.com/onnx/sklearn-onnx/blob/1.13/setup.py
`requirements.txt`: https://github.com/onnx/sklearn-onnx/blob/1.13/requirements.txt

## Changes
- Fork from CF
- Remove noarch
- Update about section
- Adjust version pinning on `scikit-learn` to match upstream
